### PR TITLE
Update imports to dbus/v5

### DIFF
--- a/AccessPoint.go
+++ b/AccessPoint.go
@@ -3,7 +3,7 @@ package gonetworkmanager
 import (
 	"encoding/json"
 
-	"github.com/godbus/dbus"
+	"github.com/godbus/dbus/v5"
 )
 
 const (

--- a/ActiveConnection.go
+++ b/ActiveConnection.go
@@ -1,7 +1,7 @@
 package gonetworkmanager
 
 import (
-	"github.com/godbus/dbus"
+	"github.com/godbus/dbus/v5"
 )
 
 const (

--- a/Checkpoint.go
+++ b/Checkpoint.go
@@ -3,7 +3,7 @@ package gonetworkmanager
 import (
 	"encoding/json"
 
-	"github.com/godbus/dbus"
+	"github.com/godbus/dbus/v5"
 )
 
 const (

--- a/Connection.go
+++ b/Connection.go
@@ -3,7 +3,7 @@ package gonetworkmanager
 import (
 	"encoding/json"
 
-	"github.com/godbus/dbus"
+	"github.com/godbus/dbus/v5"
 )
 
 const (

--- a/DHCP4Config.go
+++ b/DHCP4Config.go
@@ -3,7 +3,7 @@ package gonetworkmanager
 import (
 	"encoding/json"
 
-	"github.com/godbus/dbus"
+	"github.com/godbus/dbus/v5"
 )
 
 const (

--- a/DHCP6Config.go
+++ b/DHCP6Config.go
@@ -3,7 +3,7 @@ package gonetworkmanager
 import (
 	"encoding/json"
 
-	"github.com/godbus/dbus"
+	"github.com/godbus/dbus/v5"
 )
 
 const (

--- a/Device.go
+++ b/Device.go
@@ -3,7 +3,7 @@ package gonetworkmanager
 import (
 	"encoding/json"
 
-	"github.com/godbus/dbus"
+	"github.com/godbus/dbus/v5"
 )
 
 const (

--- a/DeviceDummy.go
+++ b/DeviceDummy.go
@@ -3,7 +3,7 @@ package gonetworkmanager
 import (
 	"encoding/json"
 
-	"github.com/godbus/dbus"
+	"github.com/godbus/dbus/v5"
 )
 
 const (

--- a/DeviceGeneric.go
+++ b/DeviceGeneric.go
@@ -3,7 +3,7 @@ package gonetworkmanager
 import (
 	"encoding/json"
 
-	"github.com/godbus/dbus"
+	"github.com/godbus/dbus/v5"
 )
 
 const (

--- a/DeviceIpTunnel.go
+++ b/DeviceIpTunnel.go
@@ -3,7 +3,7 @@ package gonetworkmanager
 import (
 	"encoding/json"
 
-	"github.com/godbus/dbus"
+	"github.com/godbus/dbus/v5"
 )
 
 const (

--- a/DeviceStatistics.go
+++ b/DeviceStatistics.go
@@ -3,7 +3,7 @@ package gonetworkmanager
 import (
 	"encoding/json"
 
-	"github.com/godbus/dbus"
+	"github.com/godbus/dbus/v5"
 )
 
 const (

--- a/DeviceWired.go
+++ b/DeviceWired.go
@@ -3,7 +3,7 @@ package gonetworkmanager
 import (
 	"encoding/json"
 
-	"github.com/godbus/dbus"
+	"github.com/godbus/dbus/v5"
 )
 
 const (

--- a/DeviceWireless.go
+++ b/DeviceWireless.go
@@ -3,7 +3,7 @@ package gonetworkmanager
 import (
 	"encoding/json"
 
-	"github.com/godbus/dbus"
+	"github.com/godbus/dbus/v5"
 )
 
 const (

--- a/IP4Config.go
+++ b/IP4Config.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 
-	"github.com/godbus/dbus"
+	"github.com/godbus/dbus/v5"
 )
 
 const (

--- a/IP6Config.go
+++ b/IP6Config.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 
-	"github.com/godbus/dbus"
+	"github.com/godbus/dbus/v5"
 )
 
 const (

--- a/NetworkManager.go
+++ b/NetworkManager.go
@@ -3,7 +3,7 @@ package gonetworkmanager
 import (
 	"encoding/json"
 
-	"github.com/godbus/dbus"
+	"github.com/godbus/dbus/v5"
 )
 
 const (

--- a/Settings.go
+++ b/Settings.go
@@ -1,7 +1,7 @@
 package gonetworkmanager
 
 import (
-	"github.com/godbus/dbus"
+	"github.com/godbus/dbus/v5"
 )
 
 const (

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,4 @@ module github.com/Wifx/gonetworkmanager
 
 go 1.12
 
-require github.com/godbus/dbus v0.0.0-20181101234600-2ff6f7ffd60f
-
-replace github.com/godbus/dbus => github.com/godbus/dbus/v5 v5.0.2
+require github.com/godbus/dbus/v5 v5.0.2

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,2 @@
-github.com/godbus/dbus v0.0.0-20181101234600-2ff6f7ffd60f h1:zlOR3rOlPAVvtfuxGKoghCmop5B0TRyu/ZieziZuGiM=
-github.com/godbus/dbus v0.0.0-20181101234600-2ff6f7ffd60f/go.mod h1:/YcGZj5zSblfDWMMoOzV4fas9FZnQYTkDnsGvmh2Grw=
+github.com/godbus/dbus/v5 v5.0.2 h1:QtWdZQyXTEn7S0LXv9nVxPUiT37d1i7UntpRTiKM86E=
 github.com/godbus/dbus/v5 v5.0.2/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=

--- a/utils.go
+++ b/utils.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"net"
 
-	"github.com/godbus/dbus"
+	"github.com/godbus/dbus/v5"
 )
 
 const (


### PR DESCRIPTION
Closes #5.  Upon merging, please create a new release tag (i.e. `v0.1.1`) for gonetworkmanager. Thank you!