### PR TITLE
added parameter specific_object for AddAndActivateConnection

### DIFF
--- a/NetworkManager.go
+++ b/NetworkManager.go
@@ -224,7 +224,7 @@ type networkManager struct {
 }
 
 func (nm *networkManager) Reload(flags uint32) error {
-	return nm.call(NetworkManagerReload)
+	return nm.call(NetworkManagerReload, flags)
 }
 
 func (nm *networkManager) GetDevices() (devices []Device, err error) {

--- a/NetworkManager.go
+++ b/NetworkManager.go
@@ -301,7 +301,7 @@ func (nm *networkManager) AddAndActivateConnection(connection map[string]map[str
 	var opath1 dbus.ObjectPath
 	var opath2 dbus.ObjectPath
 
-	err = nm.callWithReturn2(&opath1, &opath2, NetworkManagerAddAndActivateConnection, connection, d.GetPath())
+	err = nm.callWithReturn2(&opath1, &opath2, NetworkManagerAddAndActivateConnection, connection, d.GetPath(), dbus.ObjectPath("/"))
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
When I use the call AddAndActivateConnection I have this error
`Type of message, “(a{sa{sv}}o)”, does not match expected type “(a{sa{sv}}oo)”`

In the [specification](https://developer.gnome.org/NetworkManager/1.16/gdbus-org.freedesktop.NetworkManager.html#gdbus-method-org-freedesktop-NetworkManager.AddAndActivateConnection) the call AddAndActivateConnection require three parameters. In your library this third parameter `specific_object` is missing. The default value for this parameter is "/"