### PR TITLE
feat(AccessPoint): add `LastSeen` property

### DIFF
--- a/AccessPoint.go
+++ b/AccessPoint.go
@@ -57,6 +57,11 @@ type AccessPoint interface {
 	// percent.
 	GetPropertyStrength() (uint8, error)
 
+	// GetPropertyLastSeen
+	// The timestamp (in CLOCK_BOOTTIME seconds) for the last  time the access point was found in scan results.
+	// A value of -1 means the access point has never been found in scan results.
+	GetPropertyLastSeen() (int32, error)
+
 	MarshalJSON() ([]byte, error)
 }
 
@@ -117,6 +122,10 @@ func (a *accessPoint) GetPropertyStrength() (uint8, error) {
 	return a.getUint8Property(AccessPointPropertyStrength)
 }
 
+func (a *accessPoint) GetPropertyLastSeen() (int32, error) {
+	return a.getInt32Property(AccessPointPropertyLastSeen)
+}
+
 func (a *accessPoint) MarshalJSON() ([]byte, error) {
 	Flags, err := a.GetPropertyFlags()
 	if err != nil {
@@ -154,6 +163,10 @@ func (a *accessPoint) MarshalJSON() ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+	LastSeen, err := a.GetPropertyLastSeen()
+	if err != nil {
+		return nil, err
+	}
 
 	return json.Marshal(map[string]interface{}{
 		"Flags":      Flags,
@@ -165,5 +178,6 @@ func (a *accessPoint) MarshalJSON() ([]byte, error) {
 		"Mode":       Mode.String(),
 		"MaxBitrate": MaxBitrate,
 		"Strength":   Strength,
+		"LastSeen":   LastSeen,
 	})
 }

--- a/utils.go
+++ b/utils.go
@@ -58,7 +58,7 @@ func (d *dbusBase) getProperty(iface string) (interface{}, error) {
 	return variant.Value(), err
 }
 
-func (d *dbusBase) setProperty(iface string, value interface{}) (error) {
+func (d *dbusBase) setProperty(iface string, value interface{}) error {
 	err := d.obj.SetProperty(iface, dbus.MakeVariant(value))
 	return err
 }
@@ -173,6 +173,19 @@ func (d *dbusBase) getUint32Property(iface string) (value uint32, err error) {
 		return
 	}
 	value, ok := prop.(uint32)
+	if !ok {
+		err = makeErrVariantType(iface)
+		return
+	}
+	return
+}
+
+func (d *dbusBase) getInt32Property(iface string) (value int32, err error) {
+	prop, err := d.getProperty(iface)
+	if err != nil {
+		return
+	}
+	value, ok := prop.(int32)
 	if !ok {
 		err = makeErrVariantType(iface)
 		return


### PR DESCRIPTION
The property field can be seen as available here:
https://developer-old.gnome.org/NetworkManager/stable/gdbus-org.freedesktop.NetworkManager.AccessPoint.html#gdbus-property-org-freedesktop-NetworkManager-AccessPoint.LastSeen

Its also showing, in the `Body` of the recieved dBus signal on the
`Subscribe()` method.
