### PR TITLE
fix prefixes and metrics as uint8 to uint32

### DIFF
--- a/IP4Config.go
+++ b/IP4Config.go
@@ -35,7 +35,7 @@ type IP4Address struct {
 
 type IP4AddressData struct {
 	Address string
-	Prefix  uint8
+	Prefix  uint32
 }
 
 // Deprecated: use IP4RouteData instead
@@ -48,9 +48,9 @@ type IP4Route struct {
 
 type IP4RouteData struct {
 	Destination          string
-	Prefix               uint8
+	Prefix               uint32
 	NextHop              string
-	Metric               uint8
+	Metric               uint32
 	AdditionalAttributes map[string]string
 }
 
@@ -151,7 +151,7 @@ func (c *ip4Config) GetPropertyAddressData() ([]IP4AddressData, error) {
 
 		ret[i] = IP4AddressData{
 			Address: address,
-			Prefix:  uint8(prefix),
+			Prefix:  prefix,
 		}
 	}
 
@@ -208,7 +208,7 @@ func (c *ip4Config) GetPropertyRouteData() ([]IP4RouteData, error) {
 				if !ok {
 					return routes, errors.New("unexpected variant type for prefix")
 				}
-				route.Prefix = uint8(prefix)
+				route.Prefix = prefix
 			case "next-hop":
 				nextHop, ok := routeDataAttribute.Value().(string)
 				if !ok {
@@ -220,7 +220,7 @@ func (c *ip4Config) GetPropertyRouteData() ([]IP4RouteData, error) {
 				if !ok {
 					return routes, errors.New("unexpected variant type for metric")
 				}
-				route.Metric = uint8(metric)
+				route.Metric = metric
 			default:
 				if route.AdditionalAttributes == nil {
 					route.AdditionalAttributes = make(map[string]string)

--- a/IP6Config.go
+++ b/IP6Config.go
@@ -32,7 +32,7 @@ type IP6Address struct {
 
 type IP6AddressData struct {
 	Address string
-	Prefix  uint8
+	Prefix  uint32
 }
 
 // Deprecated: use IP6RouteData instead
@@ -45,9 +45,9 @@ type IP6Route struct {
 
 type IP6RouteData struct {
 	Destination          string
-	Prefix               uint8
+	Prefix               uint32
 	NextHop              string
-	Metric               uint8
+	Metric               uint32
 	AdditionalAttributes map[string]string
 }
 
@@ -110,7 +110,7 @@ func (c *ip6Config) GetPropertyAddressData() ([]IP6AddressData, error) {
 
 		ret[i] = IP6AddressData{
 			Address: address,
-			Prefix:  uint8(prefix),
+			Prefix:  prefix,
 		}
 	}
 
@@ -146,7 +146,7 @@ func (c *ip6Config) GetPropertyRouteData() ([]IP6RouteData, error) {
 				if !ok {
 					return routes, errors.New("unexpected variant type for prefix")
 				}
-				route.Prefix = uint8(prefix)
+				route.Prefix = prefix
 			case "next-hop":
 				nextHop, ok := routeDataAttribute.Value().(string)
 				if !ok {
@@ -158,7 +158,7 @@ func (c *ip6Config) GetPropertyRouteData() ([]IP6RouteData, error) {
 				if !ok {
 					return routes, errors.New("unexpected variant type for metric")
 				}
-				route.Metric = uint8(metric)
+				route.Metric = metric
 			default:
 				if route.AdditionalAttributes == nil {
 					route.AdditionalAttributes = make(map[string]string)


### PR DESCRIPTION
According to https://www.networkmanager.dev/docs/api/latest/nm-settings-dbus.html prefixes and metrics are uint32 and not uint8, this fixes this issue.